### PR TITLE
Fixed the modal Width

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,13 @@
 {
   "name": "vue-cookie-consent-banner",
-  "version": "0.0.1",
+  "version": "0.0.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "vue-cookie-consent-banner",
-      "version": "0.0.1",
+      "version": "0.0.3",
+      "license": "MIT",
       "dependencies": {
         "@vue/cli-service": "^5.0.8",
         "vue": "^3.2.38"

--- a/src/components/CookieModal.vue
+++ b/src/components/CookieModal.vue
@@ -177,6 +177,7 @@ const decline = () => {
 }
 
 .modal {
+  max-width: 1055px;
   background: #ffffff;
   box-shadow: #c0c0c195 0px 7px 29px 0px;
   overflow-x: auto;


### PR DESCRIPTION
## Description
When clicked on option button the width used to increase but now it remains the same width 

Before
![image](https://user-images.githubusercontent.com/91898040/194011695-ea959471-dade-4cb0-97b6-2aaeb8667e63.png)


After
![image](https://user-images.githubusercontent.com/91898040/194011439-3ee234bb-bb39-437a-a758-fb80cab2ef93.png)


---
## Issue Ticket Number
Fixes #42 

---
## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)


---
# Checklist:
- [x] I have followed the contributing guidelines of this project as mentioned in [CONTRIBUTING.md](/CONTRIBUTING.md)
- [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/Gismo1337/vue-cookie-consent-banner/pulls) for the same update/change?
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes needed to the documentation
