### PR TITLE
[Bug] Cookie name and subtext are not clickable #51 resolving

### DIFF
--- a/src/components/CookieModal.vue
+++ b/src/components/CookieModal.vue
@@ -213,17 +213,18 @@ const toggleOptions = () => {
 
 .check-group {
   padding: 10px; /* Some padding */
-  cursor: pointer; /* Pointer/hand icon */
+  cursor: default; /* Cursor default icon */
   float: left; /* Float the checkboxes side by side */
   color: rgb(93, 92, 92);
 }
 
 .check-group input {
   margin-right: 10px;
+  cursor: pointer; /* Cursor pointer icon */
 }
 
 .check-group label{
-  cursor: pointer; /* label cursor set pointer */
+  cursor: default; /* label cursor set default */
 }
 
 .modal-fade-enter,


### PR DESCRIPTION
## Description
<!-- Include a summary of the change made and also list the dependencies that are required if any -->
Basically the cursor stays the normal cursor on the text and changes to the pointer on the checkbox
---
## Issue Ticket Number
Fixes #51 

---
## Type of change
<!-- Please select all options that are applicable. -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

---
# Checklist:
- [x] I have followed the contributing guidelines of this project as mentioned in [CONTRIBUTING.md](/CONTRIBUTING.md)
- [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/Gismo1337/vue-cookie-consent-banner/pulls) for the same update/change?
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes needed to the documentation
