### PR TITLE
feat: Add fade transition for cookie options

### DIFF
--- a/src/components/CookieModal.vue
+++ b/src/components/CookieModal.vue
@@ -75,32 +75,33 @@ const decline = () => {
             them off in settings.
           </slot>
         </section>
-
-        <section v-if="showOptions" class="modal-options" id="options">
-          <slot name="options">
-            <div class="check-group">
-              <input
-                type="checkbox"
-                id="analytics"
-                v-model="cookiesStatus.analytics"
-              />
-              <label for="analytics">Analytics</label>
-            </div>
-            <div class="check-group">
-              <input
-                type="checkbox"
-                id="marketing"
-                v-model="cookiesStatus.marketing"
-              />
-              <label for="marketing">Marketing</label>
-            </div>
-            <div class="check-group">
-              <!-- NO v-model because required! -->
-              <input checked disabled type="checkbox" id="essential" />
-              <label for="essential">Essential</label>
-            </div>
-          </slot>
-        </section>
+        <transition name="slide-fade" mode="out-in">
+          <section v-if="showOptions" class="modal-options" id="options">
+              <slot name="options">
+                <div class="check-group">
+                  <input
+                    type="checkbox"
+                    id="analytics"
+                    v-model="cookiesStatus.analytics"
+                  />
+                  <label for="analytics">Analytics</label>
+                </div>
+                <div class="check-group">
+                  <input
+                    type="checkbox"
+                    id="marketing"
+                    v-model="cookiesStatus.marketing"
+                  />
+                  <label for="marketing">Marketing</label>
+                </div>
+                <div class="check-group">
+                  <!-- NO v-model because required! -->
+                  <input checked disabled type="checkbox" id="essential" />
+                  <label for="essential">Essential</label>
+                </div>
+              </slot>
+          </section>
+        </transition>
 
         <footer class="modal-footer">
           <slot name="footer">
@@ -262,6 +263,22 @@ const decline = () => {
 .modal-fade-enter-active,
 .modal-fade-leave-active {
   transition: opacity 0.5s ease;
+}
+
+.slide-fade-enter-active,
+.slide-fade-leave-active {
+  transition: all .4s ease-out;
+  overflow: hidden;
+}
+
+.slide-fade-enter-to,
+.slide-fade-leave-from {
+  height: 44px;
+}
+.slide-fade-enter-from,
+.slide-fade-leave-to {
+  height: 0;
+  opacity: 0;
 }
 
 label {


### PR DESCRIPTION
## Description
- The v-if'd div of checkboxes have been wrapped in a transition tag
- A vue transition class called `slide-fade` was added to define how it should enter and exit

The main issue is that I hardcoded the starting height of the div during the transition to 44px.
https://github.com/alexjharrison/vue-cookie-consent-banner/blob/20-cookie-options-transition/src/components/CookieModal.vue#L276


Setting to `height: 100%` broke the transition and reading the height with JS reports a height of 0px when in a closed state.  Not sure how to handle this when the slot is overwritten.


---
## Issue Ticket Number
Fixes #20

---
## Type of change
<!-- Please select all options that are applicable. -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

---
# Checklist:
- [x] I have followed the contributing guidelines of this project as mentioned in [CONTRIBUTING.md](/CONTRIBUTING.md)
- [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/Gismo1337/vue-cookie-consent-banner/pulls) for the same update/change?
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes needed to the documentation
