### PR TITLE
Align X Icon With Title Text

### DIFF
--- a/src/components/CookieModal.vue
+++ b/src/components/CookieModal.vue
@@ -155,8 +155,9 @@ const toggleOptions = () => {
 
 .btn-close {
   position: absolute;
-  top: 0;
+  top: 50%;
   right: 0;
+  transform: translate(-50%, -50%);
   border: none;
   font-size: 20px;
   padding: 15px;
@@ -170,6 +171,8 @@ const toggleOptions = () => {
   width: 20px;
   height: 20px;
   fill: #4aae9b;
+  position:absolute;
+  transform: translate(-50%, -50%);
 }
 
 .btn-group button {


### PR DESCRIPTION
## Description

- Amended CSS to align the X icon vertically with the title text:

<img width="1120" alt="Screenshot 2022-10-05 at 22 39 23" src="https://user-images.githubusercontent.com/24946946/194169344-3b68995c-ed9d-4525-8793-649a589c9b91.png">

---
## Issue Ticket Number
Fixes #54 



---
## Type of change
<!-- Please select all options that are applicable. -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

---
# Checklist:
- [x] I have followed the contributing guidelines of this project as mentioned in [CONTRIBUTING.md](/CONTRIBUTING.md)
- [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/Gismo1337/vue-cookie-consent-banner/pulls) for the same update/change?
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes needed to the documentation
